### PR TITLE
Replace local definition of OrganisationType with common

### DIFF
--- a/src/SFA.DAS.ReferenceData.Types/packages.config
+++ b/src/SFA.DAS.ReferenceData.Types/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="SFA.DAS.Common.Domain" version="1.3.0.44308" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
The OrganisationType _type_ has hitherto not been visible to clients, although the values have been. With the addition of the GetById method the OrganisationType  _type_ needed to made available to clients. So it was moved to a ReferencetData common types project. However, it turns out that OrganisationType is _also_ defined in the DAS.CommonTypes project and that is what is used by the clients. As both referencedata and clients both need a common type for OrganisationType, and given that the common types definition is already released in the wild, ReferenceData will therefore have to use this definition in preference to its own.